### PR TITLE
Modify dockerfiles

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -812,8 +812,7 @@
     "util/metautils",
   ]
   pruneopts = "T"
-  revision = "c250d6563d4d4c20252cd865923440e829844f4e"
-  version = "v1.0.0"
+  revision = "27f3801344b24dd6e9c608692368947f674a8298"
 
 [[projects]]
   digest = "0:"
@@ -1313,14 +1312,7 @@
 [[projects]]
   digest = "0:"
   name = "github.com/openzipkin/zipkin-go-opentracing"
-  packages = [
-    ".",
-    "flag",
-    "thrift/gen-go/scribe",
-    "thrift/gen-go/zipkincore",
-    "types",
-    "wire",
-  ]
+  packages = ["."]
   pruneopts = "T"
   revision = "f0f479ad013a498e4cbfb369414e5d3880903779"
   version = "v0.3.5"
@@ -1742,6 +1734,18 @@
   packages = ["."]
   pruneopts = "T"
   revision = "1d9901ca382bfae82f47b1ddb5fb67a019d254e8"
+
+[[projects]]
+  branch = "master"
+  digest = "0:"
+  name = "github.com/rai-project/tensorflow"
+  packages = [
+    ".",
+    "graph",
+    "predictor",
+  ]
+  pruneopts = "T"
+  revision = "b92e42aa59035aca3fc01a6efd2648da0dcd253e"
 
 [[projects]]
   branch = "master"
@@ -2661,6 +2665,9 @@
     "github.com/rai-project/image/types",
     "github.com/rai-project/logger",
     "github.com/rai-project/nvidia-smi",
+    "github.com/rai-project/tensorflow",
+    "github.com/rai-project/tensorflow/graph",
+    "github.com/rai-project/tensorflow/predictor",
     "github.com/rai-project/tracer",
     "github.com/rai-project/tracer/jaeger",
     "github.com/sirupsen/logrus",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -128,6 +128,10 @@
   branch = "master"
   name = "github.com/VividCortex/robustly"
 
+[[override]]
+  name = "github.com/grpc-ecosystem/go-grpc-middleware"
+  revision = "27f3801344b24dd6e9c608692368947f674a8298"
+
 [prune]
   go-tests = true
 

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -128,10 +128,6 @@
   branch = "master"
   name = "github.com/VividCortex/robustly"
 
-[[override]]
-  name = "github.com/grpc-ecosystem/go-grpc-middleware"
-  revision = "27f3801344b24dd6e9c608692368947f674a8298"
-
 [prune]
   go-tests = true
 

--- a/tensorflow-agent/dockerfiles/Dockerfile.amd64_cpu
+++ b/tensorflow-agent/dockerfiles/Dockerfile.amd64_cpu
@@ -70,8 +70,8 @@ RUN git clone --depth=1 --branch=master https://${PKG}.git . && \
 
 RUN cd ${GOPATH}/src/$PKG/vendor/github.com/tensorflow/tensorflow && \
   export GCC_HOST_COMPILER_PATH=/usr/bin/gcc && \
-  export PYTHON_BIN_PATH=/usr/bin/python && \
-  export USE_DEFAULT_PYTHON_LIB_PATH=1 && \
+  export PYTHON_BIN_PATH=/usr/bin/python3.6 && \
+  export PYTHON_LIB_PATH=/usr/lib/python3.6/dist-packages && \
   export TF_NEED_GCP=1 && \
   export TF_NEED_HDFS=1 && \
   export TF_NEED_JEMALLOC=1 && \

--- a/tensorflow-agent/dockerfiles/Dockerfile.amd64_cpu
+++ b/tensorflow-agent/dockerfiles/Dockerfile.amd64_cpu
@@ -43,7 +43,7 @@ RUN add-apt-repository ppa:webupd8team/java &&\
   rm -rf /var/lib/apt/lists/*
 
 # Install bazel
-ENV BAZEL_VERSION 0.19.2
+ENV BAZEL_VERSION 0.24.1
 RUN apt-get update && \
 	apt-get install -y --no-install-recommends \
    bash-completion \

--- a/tensorflow-agent/dockerfiles/Dockerfile.amd64_gpu
+++ b/tensorflow-agent/dockerfiles/Dockerfile.amd64_gpu
@@ -47,7 +47,7 @@ RUN add-apt-repository ppa:webupd8team/java &&\
   rm -rf /var/lib/apt/lists/*
 
 # Install bazel
-ENV BAZEL_VERSION 0.19.2
+ENV BAZEL_VERSION 0.24.1
 RUN apt-get update && \
 	apt-get install -y --no-install-recommends \
    bash-completion \

--- a/tensorflow-agent/dockerfiles/Dockerfile.amd64_gpu
+++ b/tensorflow-agent/dockerfiles/Dockerfile.amd64_gpu
@@ -75,8 +75,8 @@ RUN git clone --depth=1 --branch=master https://${PKG}.git . && \
 
 RUN cd ${GOPATH}/src/$PKG/vendor/github.com/tensorflow/tensorflow && \
   export GCC_HOST_COMPILER_PATH=/usr/bin/gcc && \
-  export PYTHON_BIN_PATH=/usr/bin/python && \
-  export USE_DEFAULT_PYTHON_LIB_PATH=1 && \
+  export PYTHON_BIN_PATH=/usr/bin/python3.6 && \
+  export PYTHON_LIB_PATH=/usr/lib/python3.6/dist-packages && \
   export TF_NEED_GCP=1 && \
   export TF_NEED_HDFS=1 && \
   export TF_NEED_JEMALLOC=1 && \
@@ -96,7 +96,7 @@ RUN cd ${GOPATH}/src/$PKG/vendor/github.com/tensorflow/tensorflow && \
   ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 && \
   export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LD_LIBRARY_PATH} && \
   tensorflow/tools/ci_build/builds/configured GPU \
-  bazel build -c opt --local_resources=32000,8,1.0 --config=cuda --incompatible_remove_native_http_archive=false --define=grpc_no_ares=true //tensorflow:libtensorflow.so
+  bazel build -c opt --local_resources=32000,8,1.0 --config=cuda --define=grpc_no_ares=true //tensorflow:libtensorflow.so
 
 RUN	export LD_LIBRARY_PATH=${GOPATH}/src/$PKG/vendor/github.com/tensorflow/tensorflow/bazel-bin/tensorflow:${LD_LIBRARY_PATH} && \
   ls -la ${GOPATH}/src/$PKG/vendor/github.com/tensorflow/tensorflow/bazel-bin/tensorflow && \

--- a/tensorflow-agent/dockerfiles/Dockerfile.amd64_gpu_ngc
+++ b/tensorflow-agent/dockerfiles/Dockerfile.amd64_gpu_ngc
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/tensorflow:19.05-py2
+FROM nvcr.io/nvidia/tensorflow:19.06-py3
 
 # Build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE

--- a/tensorflow-agent/dockerfiles/Dockerfile.amd64_gpu_ngc
+++ b/tensorflow-agent/dockerfiles/Dockerfile.amd64_gpu_ngc
@@ -21,11 +21,6 @@ LABEL org.carml.tensorflow.build-date=$BUILD_DATE \
 
 ########## INSTALLATION STEPS ###################
 
-# install pre-requisites
-#RUN apt-get update -y && apt-get install -y --no-install-recommends \
-#    bison && \
-#    rm -rf /var/lib/apt/lists/*
-
 # Install Go
 ENV GIMME_GO_VERSION "1.12"
 ENV GIMME_OS "linux"

--- a/tensorflow-agent/dockerfiles/Dockerfile.amd64_gpu_ngc
+++ b/tensorflow-agent/dockerfiles/Dockerfile.amd64_gpu_ngc
@@ -53,7 +53,7 @@ RUN ln -s /usr/local/lib/tensorflow/libtensorflow_cc.so /usr/local/lib/tensorflo
 RUN go get -u github.com/golang/dep/cmd/dep
 
 # get rai-project/tensorflow repository
-ENV PKG github.com/yhchang3/tensorflow
+ENV PKG github.com/rai-project/tensorflow
 WORKDIR $GOPATH/src/$PKG
 
 RUN git clone --depth=1 --branch=master https://${PKG}.git . && \

--- a/tensorflow-agent/dockerfiles/Dockerfile.amd64_gpu_ngc
+++ b/tensorflow-agent/dockerfiles/Dockerfile.amd64_gpu_ngc
@@ -21,45 +21,49 @@ LABEL org.carml.tensorflow.build-date=$BUILD_DATE \
 
 ########## INSTALLATION STEPS ###################
 
-SHELL ["/bin/bash","-c"]
-
-ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
-
 # install pre-requisites
-RUN apt-get update -y && apt-get install -y --no-install-recommends \
-    bison && \
-    rm -rf /var/lib/apt/lists/*
+#RUN apt-get update -y && apt-get install -y --no-install-recommends \
+#    bison && \
+#    rm -rf /var/lib/apt/lists/*
 
-# install gvm
-RUN bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer)
+# Install Go
+ENV GIMME_GO_VERSION "1.12"
+ENV GIMME_OS "linux"
+ENV GIMME_ARCH $ARCH
 
-RUN echo '[[ -s "/root/.gvm/scripts/gvm" ]] && source "/root/.gvm/scripts/gvm"' > /etc/bash.bashrc
+LABEL org.golang.version=$GIMME_GO_VERSION
+LABEL org.golang.os=$GIMME_OS
+LABEL org.golang.arch=$GIMME_ARCH
 
-# install Go
-RUN gvm install go1.12 -B && gvm use go1.12 --default
+ADD https://raw.githubusercontent.com/travis-ci/gimme/master/gimme /usr/bin/gimme
+RUN chmod +x /usr/bin/gimme
+RUN gimme
 
-ENV GOPATH=/root/.gvm/pkgsets/go1.12/global
-ENV GOROOT=/root/.gvm/gos/go1.12
-ENV PATH=$GOROOT/bin:$PATH
+ENV GOROOT "/root/.gimme/versions/go${GIMME_GO_VERSION}.${GIMME_OS}.${GIMME_ARCH}"
+ENV PATH ${GOROOT}/bin:${PATH}
+
+ENV GOPATH "/go"
+ENV PATH $GOPATH/bin:$PATH
+
+ENV LD_LIBRARY_PATH /usr/local/cuda/extras/CUPTI/lib64:$LD_LIBRARY_PATH
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/tensorflow
 ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
 ENV CGO_LDFLAGS="${CGO_LDFLAGS} -L /usr/local/lib/tensorflow/"
+
+RUN ln -s /usr/local/lib/tensorflow/libtensorflow_cc.so /usr/local/lib/tensorflow/libtensorflow.so && \
+    ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1
+
+# Install Go packages
+RUN go get -u github.com/golang/dep/cmd/dep
 
 # get rai-project/tensorflow repository
 ENV PKG github.com/rai-project/tensorflow
 WORKDIR $GOPATH/src/$PKG
 
-RUN go get -u github.com/golang/dep/cmd/dep
-
 RUN git clone --depth=1 --branch=master https://${PKG}.git . && \
     dep ensure -vendor-only -v
 
-RUN ln -s /usr/local/lib/tensorflow/libtensorflow_cc.so /usr/local/lib/tensorflow/libtensorflow.so && \
-    ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 
-
 RUN cd tensorflow-agent && go build -tags="nolibjpeg" && \
     cd .. && rm -fr vendor
-
-RUN cd tensorflow-agent && ./tensorflow-agent -h
 
 #ENTRYPOINT ["tensorflow-agent"]

--- a/tensorflow-agent/dockerfiles/Dockerfile.amd64_gpu_ngc
+++ b/tensorflow-agent/dockerfiles/Dockerfile.amd64_gpu_ngc
@@ -45,6 +45,7 @@ ENV PATH ${GOROOT}/bin:${PATH}
 ENV GOPATH "/go"
 ENV PATH $GOPATH/bin:$PATH
 
+#Setup Environment
 ENV LD_LIBRARY_PATH /usr/local/cuda/extras/CUPTI/lib64:$LD_LIBRARY_PATH
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/tensorflow
 ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
@@ -57,7 +58,7 @@ RUN ln -s /usr/local/lib/tensorflow/libtensorflow_cc.so /usr/local/lib/tensorflo
 RUN go get -u github.com/golang/dep/cmd/dep
 
 # get rai-project/tensorflow repository
-ENV PKG github.com/rai-project/tensorflow
+ENV PKG github.com/yhchang3/tensorflow
 WORKDIR $GOPATH/src/$PKG
 
 RUN git clone --depth=1 --branch=master https://${PKG}.git . && \

--- a/tensorflow-agent/dockerfiles/Makefile
+++ b/tensorflow-agent/dockerfiles/Makefile
@@ -71,7 +71,7 @@ docker_pull_gpu:
 	docker pull carml/base:$(ARCH)-gpu-latest
 
 docker_pull_gpu_ngc:
-	docker pull nvcr.io/nvidia/tensorflow:19.05-py2
+	docker pull nvcr.io/nvidia/tensorflow:19.06-py3
 
 docker_pull: docker_pull_cpu docker_pull_gpu docker_pull_gpu_ngc
 


### PR DESCRIPTION
Base dockerfile for ngc on python3 and change the mechanism for installing go.

Change Bazel to 0.24.1 to fit tensorflow 1.14 in dockerfile for cpu and gpu, but still have some issues when building.