### PR TITLE
fix source directory

### DIFF
--- a/tensorflow-agent/dockerfiles/Dockerfile.amd64_cpu
+++ b/tensorflow-agent/dockerfiles/Dockerfile.amd64_cpu
@@ -91,9 +91,8 @@ RUN cd ${GOPATH}/src/$PKG/vendor/github.com/tensorflow/tensorflow && \
 RUN	ls -la ${GOPATH}/src/$PKG/vendor/github.com/tensorflow/tensorflow/bazel-bin/tensorflow && \
 	cp ${GOPATH}/src/$PKG/vendor/github.com/tensorflow/tensorflow/bazel-bin/tensorflow/libtensorflow.so.1.14.0 /usr/local/lib/libtensorflow.so && \
 	cp ${GOPATH}/src/$PKG/vendor/github.com/tensorflow/tensorflow/bazel-bin/tensorflow/libtensorflow_framework.so.1.14.0 /usr/local/lib/libtensorflow_framework.so.1 && \
-	mkdir -p /usr/local/include/tensorflow/c && \
-	cp -r ${GOPATH}/src/$PKG/vendor/github.com/tensorflow/tensorflow/bazel-bin/tensorflow/c /usr/local/include/tensorflow/c && \
-	ls /usr/local/include/tensorflow/c
+	mkdir /usr/local/include/tensorflow && \
+	cp -r ${GOPATH}/src/$PKG/vendor/github.com/tensorflow/tensorflow/tensorflow/c /usr/local/include/tensorflow
 
 ENV CGO_CFLAGS="${CGO_CFLAGS} -I /usr/local/include"
 ENV CGO_CXXFLAGS="${CGO_CXXFLAGS} -I /usr/local/include"

--- a/tensorflow-agent/dockerfiles/Dockerfile.amd64_gpu
+++ b/tensorflow-agent/dockerfiles/Dockerfile.amd64_gpu
@@ -106,9 +106,8 @@ RUN cd ${GOPATH}/src/$PKG/vendor/github.com/tensorflow/tensorflow && \
 RUN	ls -la ${GOPATH}/src/$PKG/vendor/github.com/tensorflow/tensorflow/bazel-bin/tensorflow && \
     cp ${GOPATH}/src/$PKG/vendor/github.com/tensorflow/tensorflow/bazel-bin/tensorflow/libtensorflow.so.1.14.0 /usr/local/lib/libtensorflow.so && \
 	cp ${GOPATH}/src/$PKG/vendor/github.com/tensorflow/tensorflow/bazel-bin/tensorflow/libtensorflow_framework.so.1.14.0 /usr/local/lib/libtensorflow_framework.so.1 && \
-	mkdir -p /usr/local/include/tensorflow/c && \
-	cp -r ${GOPATH}/src/$PKG/vendor/github.com/tensorflow/tensorflow/bazel-bin/tensorflow/c /usr/local/include/tensorflow/c && \
-	ls /usr/local/include/tensorflow/c
+	mkdir /usr/local/include/tensorflow && \
+	cp -r ${GOPATH}/src/$PKG/vendor/github.com/tensorflow/tensorflow/tensorflow/c /usr/local/include/tensorflow
 
 ENV CGO_CFLAGS="${CGO_CFLAGS} -I /usr/local/include"
 ENV CGO_CXXFLAGS="${CGO_CXXFLAGS} -I /usr/local/include"


### PR DESCRIPTION
The vendor/github.com/tensorflow/tensorflow/bazel-bin/tensorflow/c doesn't contain c_api.h, so copy this directory from the original place (vendor/github.com/tensorflow/tensorflow/tensorflow/c).
And fix the previous wrong copy syntax.

Already tested the go build command on the unfinished docker images locally. So this fix should make the CI build passed.