### PR TITLE
Fix forceexport and update readme for the agent usage with docker

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -461,7 +461,6 @@
     "pkg/jsonmessage",
     "pkg/longpath",
     "pkg/mount",
-    "pkg/parsers",
     "pkg/pools",
     "pkg/progress",
     "pkg/signal",
@@ -1516,7 +1515,7 @@
     "steps",
   ]
   pruneopts = "T"
-  revision = "f85e36865eb4de8fad997f06934263b0a207db92"
+  revision = "4aaa12cfa5874a785cbe70a2bc8a849472c7bc95"
 
 [[projects]]
   branch = "master"
@@ -1782,6 +1781,18 @@
 [[projects]]
   branch = "master"
   digest = "0:"
+  name = "github.com/rai-project/tensorflow"
+  packages = [
+    ".",
+    "graph",
+    "predictor",
+  ]
+  pruneopts = "T"
+  revision = "202663a68df3165460f14ccf7dad93eaf90a3796"
+
+[[projects]]
+  branch = "master"
+  digest = "0:"
   name = "github.com/rai-project/tracer"
   packages = [
     ".",
@@ -1798,7 +1809,7 @@
     "zipkin",
   ]
   pruneopts = "T"
-  revision = "7dcecc9e08b5279b7849775ec21d8b69bc05a117"
+  revision = "97d6a9677dc3a0e73fc9df74d366323884c19190"
 
 [[projects]]
   branch = "master"
@@ -2755,7 +2766,6 @@
   analyzer-version = 1
   input-imports = [
     "github.com/Unknwon/com",
-    "github.com/alangpierce/go-forceexport",
     "github.com/cheekybits/genny/generic",
     "github.com/elazarl/go-bindata-assetfs",
     "github.com/gogo/protobuf/proto",
@@ -2779,6 +2789,9 @@
     "github.com/rai-project/image/types",
     "github.com/rai-project/logger",
     "github.com/rai-project/nvidia-smi",
+    "github.com/rai-project/tensorflow",
+    "github.com/rai-project/tensorflow/graph",
+    "github.com/rai-project/tensorflow/predictor",
     "github.com/rai-project/tracer",
     "github.com/rai-project/tracer/jaeger",
     "github.com/sirupsen/logrus",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,8 +21,7 @@ jobs:
           ./push.sh docker_push_gpu
   - job: GPU_NGC
     timeoutInMinutes: 0
-    pool:
-      vmImage: "Ubuntu 16.04"
+    pool: 'Impact2'
     steps:
       - bash: |
           docker login -u $(DOCKER_USERNAME) -p $(DOCKER_PASSWORD)

--- a/predictor/session.go
+++ b/predictor/session.go
@@ -333,7 +333,7 @@ func newCRunArgs(feeds map[Output]*Tensor, fetches []Output, targets []*Operatio
 func (c *cRunArgs) toGo() []*Tensor {
 	ret := make([]*Tensor, len(c.fetchTensors))
 	for i, ct := range c.fetchTensors {
-		ret[i] = newTensorFromC(ct)
+		ret[i] = tensor_newTensorFromC(ct)
 	}
 	return ret
 }

--- a/tensorflow-agent/dockerfiles/Dockerfile.amd64_gpu
+++ b/tensorflow-agent/dockerfiles/Dockerfile.amd64_gpu
@@ -22,10 +22,9 @@ LABEL org.carml.tensorflow.build-date=$BUILD_DATE \
 
 ########## INSTALLATION STEPS ###################
 
-ENV LD_LIBRARY_PATH /usr/local/cuda/extras/CUPTI/lib64:$LD_LIBRARY_PATH
-ENV LD_LIBRARY_PATH /usr/local/cuda/lib64:$LD_LIBRARY_PATH
-ENV LD_LIBRARY_PATH /usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
-ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LD_LIBRARY_PATH}
+# Setup LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH /usr/local/cuda/extras/CUPTI/lib64:/usr/local/cuda/extras/CUPTI/lib64:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH /usr/local/cuda/lib64/stubs:/usr/lib/x86_64-linux-gnu:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
 
 RUN add-apt-repository ppa:webupd8team/java &&\
   apt-get update -y && apt-get install -y --no-install-recommends \
@@ -72,6 +71,7 @@ WORKDIR $GOPATH/src/$PKG
 
 RUN git clone --depth=1 --branch=master https://${PKG}.git .
 
+# Update frequently modified deps and genereate vendor
 RUN dep ensure -v -no-vendor -update \
     github.com/rai-project/dlframework \
     github.com/rai-project/evaluation && \
@@ -106,9 +106,9 @@ RUN	ls -la ${GOPATH}/src/$PKG/vendor/github.com/tensorflow/tensorflow/bazel-bin/
     cp ${GOPATH}/src/$PKG/vendor/github.com/tensorflow/tensorflow/bazel-bin/tensorflow/libtensorflow.so.1.14.0 /usr/local/lib/libtensorflow.so && \
     ln -s /usr/local/lib/libtensorflow.so /usr/local/lib/libtensorflow.so.1 && \
     ln -s /usr/local/cuda-10.1/targets/x86_64-linux/lib/stubs/libnvidia-ml.so /usr/local/cuda-10.1/targets/x86_64-linux/lib/stubs/libnvidia-ml.so.1 && \
-	cp ${GOPATH}/src/$PKG/vendor/github.com/tensorflow/tensorflow/bazel-bin/tensorflow/libtensorflow_framework.so.1.14.0 /usr/local/lib/libtensorflow_framework.so.1 && \
-	mkdir /usr/local/include/tensorflow && \
-	cp -r ${GOPATH}/src/$PKG/vendor/github.com/tensorflow/tensorflow/tensorflow/c /usr/local/include/tensorflow
+	  cp ${GOPATH}/src/$PKG/vendor/github.com/tensorflow/tensorflow/bazel-bin/tensorflow/libtensorflow_framework.so.1.14.0 /usr/local/lib/libtensorflow_framework.so.1 && \
+	  mkdir /usr/local/include/tensorflow && \
+	  cp -r ${GOPATH}/src/$PKG/vendor/github.com/tensorflow/tensorflow/tensorflow/c /usr/local/include/tensorflow
 
 RUN ldconfig
 
@@ -121,5 +121,9 @@ RUN cd $GOPATH/src/$PKG && \
   cd tensorflow-agent && \
   go install && \
   cd ..
+
+# Remove cuda/lib64/stubs from LD_LIBRARY_PATH since it's for building purpose
+ENV LD_LIBRARY_PATH /usr/local/cuda/extras/CUPTI/lib64:/usr/local/nvidia/lib:/usr/local/nvidia/lib64
+ENV LD_LIBRARY_PATH /usr/lib/x86_64-linux-gnu:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64:$LD_LIBRARY_PATH
 
 ENTRYPOINT ["tensorflow-agent"]

--- a/tensorflow-agent/dockerfiles/Dockerfile.amd64_gpu_ngc
+++ b/tensorflow-agent/dockerfiles/Dockerfile.amd64_gpu_ngc
@@ -41,15 +41,13 @@ ENV GOPATH "/go"
 ENV PATH $GOPATH/bin:$PATH
 
 #Setup Environment
-ENV LD_LIBRARY_PATH /usr/local/cuda/extras/CUPTI/lib64:$LD_LIBRARY_PATH
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/tensorflow
-ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
-ENV LD_LIBRARY_PATH=/usr/local/cuda-10.1/compat/lib.real:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH /usr/local/cuda/lib64/stubs:/usr/local/cuda-10.1/compat/lib.real:$LD_LIBRARY_PATH
+
 ENV CGO_CFLAGS="${CGO_CFLAGS} -I /opt/tensorflow/tensorflow-source"
 ENV CGO_CXXFLAGS="${CGO_CXXFLAGS} -I /opt/tensorflow/tensorflow-source"
 ENV CGO_LDFLAGS="${CGO_LDFLAGS} -L /usr/local/lib"
 
-RUN ln -s /usr/local/lib/tensorflow/libtensorflow_cc.so /usr/local/lib/tensorflow/libtensorflow.so && \
+RUN ln -s /usr/local/lib/tensorflow/libtensorflow_cc.so /usr/local/lib/libtensorflow.so && \
     ln -s /usr/local/cuda-10.1/targets/x86_64-linux/lib/stubs/libnvidia-ml.so /usr/local/cuda-10.1/targets/x86_64-linux/lib/stubs/libnvidia-ml.so.1
 
 # Install Go packages
@@ -68,6 +66,10 @@ RUN dep ensure -v -no-vendor -update \
 
 RUN cd tensorflow-agent && go install -tags="nolibjpeg" && \
     cd ..
+
+# Remove cuda/lib64/stubs from LD_LIBRARY_PATH since it's for building purpose
+ENV LD_LIBRARY_PATH /usr/local/cuda/compat/lib:/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/lib/tensorflow
+ENV LD_LIBRARY_PATH /usr/local/cuda-10.1/compat/lib.real:/usr/local/cuda/extras/CUPTI/lib64:$LD_LIBRARY_PATH
 
 ENTRYPOINT ["tensorflow-agent"]
 

--- a/tensorflow-agent/dockerfiles/test.sh
+++ b/tensorflow-agent/dockerfiles/test.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+svn export --force https://github.com/rai-project/mlmodelscope/trunk/carml_config.yml.example ~/.carml_config.yml
+
+docker run -d -e COLLECTOR_ZIPKIN_HTTP_PORT=9411 -p5775:5775/udp -p6831:6831/udp -p6832:6832/udp \
+  -p5778:5778 -p16686:16686 -p14268:14268 -p9411:9411 jaegertracing/all-in-one:latest
+
+docker run --gpus=all --shm-size=1g --ulimit memlock=-1 --ulimit stack=67108864 --privileged=true \
+   --network host -v ~/.carml_config.yml:/root/.carml_config.yml $1 predict urls


### PR DESCRIPTION
1. Update readme (nvidia-docker -> docker 19.03 with nvidia-container-toolkit) and add the "Use the Agent through Pre-built Docker Images" part.

2. Change the pool for azure-pipeline since the NGC image is larger than 10GB, which is not available in azure-pipeline host-agent.

3. Modify the LD_LIBRARY_PATH in Dockerfiles after building since /usr/local/cuda/lib64/stubs should be only used when building but not running the container.

4. force-export causes segfault in go1.12, changed to use Reflect to get the unexported fields in the go-binding for tensorflow. 